### PR TITLE
Revise toggle functions for page views

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -131,13 +131,9 @@ makeYourOwnPosterButton.addEventListener('click', makeOwnPoster);
 
 savedPosterButton.addEventListener('click', showSavedPoster);
 
-nevermindButton.addEventListener('click',function() {
-  backToMain(makeYourOwnPoster)
-});
+nevermindButton.addEventListener('click', makeOwnPoster);
 
-backToMainButton.addEventListener('click', function(){
-  backToMain(savedPosterPage)
-});
+backToMainButton.addEventListener('click', makeOwnPoster);
 
 showPosterButton.addEventListener('click', generatePosterFromInput);
 
@@ -161,18 +157,13 @@ function generatePoster () {
 };
 
 function makeOwnPoster() {
-    makeYourOwnPoster.classList.remove('hidden');
-    mainPosterPage.classList.add('hidden');
+    makeYourOwnPoster.classList.toggle('hidden');
+    mainPosterPage.classList.toggle('hidden');
 };
 
 function showSavedPoster() {
     savedPosterPage.classList.remove('hidden');
     mainPosterPage.classList.add('hidden');
-};
-
-function backToMain(currentPage){
-  currentPage.classList.add('hidden');
-  mainPosterPage.classList.remove('hidden');
 };
 
 function generatePosterFromInput(){
@@ -184,6 +175,5 @@ function generatePosterFromInput(){
   images.push(posterImageURL.value)
    titles.push(posterTitle.value)
   quotes.push(posterQuote.value)
-
-  backToMain(posterFormPage);
+  makeOwnPoster();
 };


### PR DESCRIPTION
*Section 1:*
Reference a related issue:
Bug - return to main button from form was broken.

*Section 2:*
Description of changes proposed:
We changed the method to toggles (rather than .add/.remove) to change back and forth between the current page (e.g. forms, or saved posters page), and the main page. 

*Section 3:*
Add mentions of team members responsible for reviewing:
@zliibbe @nvalentini21 Reviewed code over zoom call. 
